### PR TITLE
Fixed authentication status cookie with WinProcess

### DIFF
--- a/HttpModule/AuthenticationModule.vb
+++ b/HttpModule/AuthenticationModule.vb
@@ -98,7 +98,8 @@ Namespace DotNetNuke.Authentication.ActiveDirectory.HttpModules
                                               (request.RawUrl.ToLower.IndexOf( _
                                                                                (Configuration.AUTHENTICATION_LOGOFF_PAGE) _
                                                                                   .ToLower) > -1)
-                Dim blnWinProcess As Boolean = authStatus = AuthenticationStatus.WinProcess AndAlso Not blnWinLogon AndAlso Not blnWinLogoff
+                Dim blnWinProcess As Boolean = (authStatus = AuthenticationStatus.WinProcess) AndAlso (Not (blnWinLogon OrElse blnWinLogoff))
+                                    
                 SetDnnReturnToCookie(request, response, portalSettings)
                 If (authStatus = AuthenticationStatus.Undefined) OrElse (blnWinProcess) Then
                     AuthenticationController.SetStatus(portalSettings.PortalId, AuthenticationStatus.WinProcess)

--- a/HttpModule/AuthenticationModule.vb
+++ b/HttpModule/AuthenticationModule.vb
@@ -98,8 +98,9 @@ Namespace DotNetNuke.Authentication.ActiveDirectory.HttpModules
                                               (request.RawUrl.ToLower.IndexOf( _
                                                                                (Configuration.AUTHENTICATION_LOGOFF_PAGE) _
                                                                                   .ToLower) > -1)
+                Dim blnWinProcess As Boolean = authStatus = AuthenticationStatus.WinProcess AndAlso Not blnWinLogon AndAlso Not blnWinLogoff
                 SetDnnReturnToCookie(request, response, portalSettings)
-                If (authStatus = AuthenticationStatus.Undefined) OrElse (authStatus = AuthenticationStatus.WinProcess) Then
+                If (authStatus = AuthenticationStatus.Undefined) OrElse (blnWinProcess) Then
                     AuthenticationController.SetStatus(portalSettings.PortalId, AuthenticationStatus.WinProcess)
                     Dim url As String = request.RawUrl
                     Dim arrAutoIp() = config.AutoIP.Split(";")

--- a/HttpModule/AuthenticationModule.vb
+++ b/HttpModule/AuthenticationModule.vb
@@ -1,5 +1,5 @@
 '
-' DotNetNuke® - http://www.dotnetnuke.com
+' DotNetNukeÂ® - http://www.dotnetnuke.com
 ' Copyright (c) 2002-2013
 ' by DotNetNuke Corporation
 '
@@ -99,7 +99,7 @@ Namespace DotNetNuke.Authentication.ActiveDirectory.HttpModules
                                                                                (Configuration.AUTHENTICATION_LOGOFF_PAGE) _
                                                                                   .ToLower) > -1)
                 SetDnnReturnToCookie(request, response, portalSettings)
-                If (authStatus = AuthenticationStatus.Undefined) Then 'OrElse (blnWinLogon) Then
+                If (authStatus = AuthenticationStatus.Undefined) OrElse (authStatus = AuthenticationStatus.WinProcess) Then
                     AuthenticationController.SetStatus(portalSettings.PortalId, AuthenticationStatus.WinProcess)
                     Dim url As String = request.RawUrl
                     Dim arrAutoIp() = config.AutoIP.Split(";")


### PR DESCRIPTION
Currently, when a user navigate to `WindowsSignIn.aspx` and cancels the prompt for AD credentials, cookies[`AUTHENTICATION_STATUS_KEY`] will remain having `WinProcess` status.

In this case, `HttpModule.AuthenticationModule` will not be able to capture it and redirect to `WindowsSignIn.aspx` correctly